### PR TITLE
Added LCOV to code coverage dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ For simulation:
 For code coverage:
 
 - Ghdl with GCC backend.
+- LCOV
 
 For waveform:
 


### PR DESCRIPTION
Added LCOV to list of dependencies because it is not covered by the GHDL installation with GCC backend.